### PR TITLE
feat: 添加 Debug 模式切换，优化消息卡片用户体验

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,12 +10,14 @@
       "dependencies": {
         "autoprefixer": "^10.4.27",
         "lucide-vue-next": "^0.577.0",
+        "marked": "^17.0.4",
         "postcss": "^8.5.8",
         "tailwindcss": "^3.4.19",
         "vue": "^3.5.25",
         "vue-i18n": "^9.14.4"
       },
       "devDependencies": {
+        "@tailwindcss/typography": "^0.5.19",
         "@types/node": "^24.10.1",
         "@vitejs/plugin-vue": "^6.0.2",
         "@vue/tsconfig": "^0.8.1",
@@ -995,6 +997,33 @@
         "win32"
       ]
     },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
+      "integrity": "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
+    "node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmmirror.com/@types/estree/-/estree-1.0.8.tgz",
@@ -1753,6 +1782,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.4.tgz",
+      "integrity": "sha512-NOmVMM+KAokHMvjWmC5N/ZOvgmSWuqJB8FoYI019j4ogb/PeRMKoKIjReZ2w3376kkA8dSJIP8uD993Kxc0iRQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/merge2": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,12 +11,14 @@
   "dependencies": {
     "autoprefixer": "^10.4.27",
     "lucide-vue-next": "^0.577.0",
+    "marked": "^17.0.4",
     "postcss": "^8.5.8",
     "tailwindcss": "^3.4.19",
     "vue": "^3.5.25",
     "vue-i18n": "^9.14.4"
   },
   "devDependencies": {
+    "@tailwindcss/typography": "^0.5.19",
     "@types/node": "^24.10.1",
     "@vitejs/plugin-vue": "^6.0.2",
     "@vue/tsconfig": "^0.8.1",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,11 +1,16 @@
 <script setup lang="ts">
-import { ref, watch, onMounted, onUnmounted, nextTick } from 'vue'
+import { ref, watch, onMounted, onUnmounted, nextTick, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { marked } from 'marked'
 import Sidebar from './components/Sidebar.vue'
 import MainInput from './components/MainInput.vue'
 import BrowserView from './components/BrowserView.vue'
 import { useChatHistory } from './composables/useChatHistory'
+import { useDebugMode } from './composables/useDebugMode'
 
+const { t } = useI18n()
 const { sessions, activeChatId, loadSessions, createNewChat, refreshSession } = useChatHistory()
+const { debugMode } = useDebugMode()
 
 // ─── WebSocket ─────────────────────────────────────────────────────────────
 const ws = ref<WebSocket | null>(null)
@@ -94,9 +99,58 @@ function scrollToBottomIfNearBottom() {
 
 watch(messages, scrollToBottomIfNearBottom, { deep: true })
 
+function isThinkingMessage(msg: any): boolean {
+  return msg.message_key === 'common.agent_thinking' || 
+         (msg.message && msg.message.includes('thinking'))
+}
+
+function isToolCallMessage(msg: any): boolean {
+  return msg.message_key === 'common.executing_action' || 
+         (msg.message && msg.message.startsWith('Executing action:'))
+}
+
+function isTechMessage(msg: any): boolean {
+  return isThinkingMessage(msg) || isToolCallMessage(msg) || isHiddenMessage(msg)
+}
+
+function isHiddenMessage(msg: any): boolean {
+  const hiddenKeys = ['common.connected_ws', 'common.context_compressing', 'common.manual_compressing', 'common.agent_resumed', 'common.sent_resume']
+  if (hiddenKeys.includes(msg.message_key)) return true
+  if (msg.message === 'Connected to NeoFish Agent WebSocket') return true
+  if (msg.message && msg.message.includes('Context threshold reached')) return true
+  if (msg.message && msg.message.includes('Manual compression')) return true
+  if (msg.message && msg.message.includes('已发送继续执行')) return true
+  return false
+}
+
+function getToolName(msg: any): string | null {
+  if (msg.params?.tool) return msg.params.tool
+  const match = msg.message?.match(/Executing action: `(\w+)`/)
+  return match ? match[1] : null
+}
+
+function getToolDisplayName(toolName: string): string {
+  const key = `tools.${toolName}`
+  const translated = t(key)
+  return translated === key ? t('tools.default') : translated
+}
+
+function renderMarkdown(text: string): string {
+  return marked.parse(text) as string
+}
+
 function pushMessage(data: any) {
+  if (!isHiddenMessage(data) && !isTechMessage(data)) {
+    for (let i = messages.value.length - 1; i >= 0; i--) {
+      const msg = messages.value[i]
+      if (isToolCallMessage(msg) && !msg._completed) {
+        msg._completed = true
+      } else if (!isTechMessage(msg)) {
+        break
+      }
+    }
+  }
   messages.value.push(data)
-  // Update sidebar preview after agent/user messages
   if (activeChatId.value && (data.type === 'info' || data.type === 'user')) {
     const preview = (data.message || '').slice(0, 80)
     refreshSession(activeChatId.value, { preview })
@@ -308,12 +362,32 @@ onUnmounted(() => {
             </div>
             
             <div v-else-if="msg.type === 'info'" class="flex gap-3">
-              <div class="w-6 h-6 rounded-full bg-neutral-900 flex-shrink-0 flex items-center justify-center">
-                <span class="text-white text-[10px] font-bold">AI</span>
-              </div>
-              <div class="text-[15px] leading-relaxed text-neutral-700 font-serif">
-                {{ msg.type === 'info' && msg.message === 'Connected to NeoFish Agent WebSocket' ? $t('common.connected_ws') : (msg.message_key ? $t(msg.message_key, msg.params || {}) : msg.message) }}
-              </div>
+              <template v-if="isHiddenMessage(msg) && !debugMode"></template>
+              <template v-else-if="isThinkingMessage(msg) && !debugMode">
+                <div class="w-6 h-6 rounded-full bg-neutral-900 flex-shrink-0 flex items-center justify-center">
+                  <span class="text-white text-[10px] font-bold">AI</span>
+                </div>
+                <div class="text-[15px] leading-relaxed text-neutral-700 font-serif">
+                  {{ $t('status.thinking') }}
+                </div>
+              </template>
+              <template v-else-if="isToolCallMessage(msg) && !debugMode">
+                <div class="w-6 h-6 rounded-full bg-neutral-900 flex-shrink-0 flex items-center justify-center">
+                  <span class="text-white text-[10px] font-bold">AI</span>
+                </div>
+                <div class="text-[15px] leading-relaxed text-neutral-700 font-serif">
+                  {{ msg._completed ? $t('status.completed') : getToolDisplayName(getToolName(msg) || '') }}
+                </div>
+              </template>
+              <template v-else>
+                <div class="w-6 h-6 rounded-full bg-neutral-900 flex-shrink-0 flex items-center justify-center">
+                  <span class="text-white text-[10px] font-bold">AI</span>
+                </div>
+                <div 
+                  class="text-[15px] leading-relaxed text-neutral-700 font-serif prose prose-sm prose-neutral max-w-none"
+                  v-html="renderMarkdown(msg.message_key ? $t(msg.message_key, msg.params || {}) : msg.message)"
+                ></div>
+              </template>
             </div>
 
             <!-- Takeover started notification -->

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import { ref } from 'vue'
-import { PlaySquare, Settings, Compass, LayoutGrid, Languages } from 'lucide-vue-next'
+import { PlaySquare, Settings, Compass, LayoutGrid, Languages, Bug } from 'lucide-vue-next'
 import { useI18n } from 'vue-i18n'
 import ChatHistoryPanel from './ChatHistoryPanel.vue'
+import { useDebugMode } from '../composables/useDebugMode'
 
 const { locale, t } = useI18n()
+const { debugMode, toggleDebug } = useDebugMode()
 const emit = defineEmits<{
   (e: 'new-chat'): void
   (e: 'select-chat', id: string): void
@@ -60,6 +62,15 @@ function handleSelectChat(id: string) {
         >
           <Languages :size="20" stroke-width="2" />
           <span class="text-[9px] font-bold uppercase">{{ locale === 'zh' ? 'EN' : 'ZH' }}</span>
+        </button>
+
+        <button
+          @click="toggleDebug"
+          class="p-2 rounded-xl transition-all"
+          :class="debugMode ? 'text-amber-600 bg-amber-50' : 'text-neutral-400 hover:text-neutral-800 hover:bg-neutral-100'"
+          :title="debugMode ? $t('sidebar.debug_on') : $t('sidebar.debug_off')"
+        >
+          <Bug :size="20" stroke-width="2" />
         </button>
 
         <button :title="$t('sidebar.settings')" class="p-2 rounded-xl text-neutral-400 hover:text-neutral-800 hover:bg-neutral-100 transition-colors">

--- a/frontend/src/composables/useDebugMode.ts
+++ b/frontend/src/composables/useDebugMode.ts
@@ -1,0 +1,18 @@
+import { ref, watch } from 'vue'
+
+const DEBUG_KEY = 'neofish_debug_mode'
+
+const debugMode = ref(localStorage.getItem(DEBUG_KEY) === 'true')
+
+watch(debugMode, (val) => {
+  localStorage.setItem(DEBUG_KEY, String(val))
+})
+
+export function useDebugMode() {
+  return {
+    debugMode,
+    toggleDebug: () => {
+      debugMode.value = !debugMode.value
+    }
+  }
+}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -35,7 +35,9 @@
     "explore": "Explore",
     "chat": "Chat History",
     "gallery": "Gallery",
-    "settings": "Settings"
+    "settings": "Settings",
+    "debug_on": "Debug Mode: On",
+    "debug_off": "Debug Mode: Off"
   },
   "history": {
     "panel_title": "Chats",
@@ -54,5 +56,25 @@
     "url_placeholder": "Enter URL",
     "navigate": "Navigate",
     "loading": "Loading browser..."
+  },
+  "tools": {
+    "navigate": "Visiting page",
+    "click": "Clicking",
+    "type_text": "Typing",
+    "scroll": "Scrolling",
+    "snapshot": "Analyzing page",
+    "request_human_assistance": "Waiting for your confirmation",
+    "go_back": "Going back",
+    "go_forward": "Going forward",
+    "wait": "Waiting",
+    "new_tab": "Opening new tab",
+    "switch_tab": "Switching tab",
+    "close_tab": "Closing tab",
+    "finish_task": "Finishing task",
+    "default": "Executing action"
+  },
+  "status": {
+    "thinking": "Thinking...",
+    "completed": "Finished thinking"
   }
 }

--- a/frontend/src/locales/zh.json
+++ b/frontend/src/locales/zh.json
@@ -35,7 +35,9 @@
     "explore": "探索",
     "chat": "对话历史",
     "gallery": "图库",
-    "settings": "设置"
+    "settings": "设置",
+    "debug_on": "调试模式：已开启",
+    "debug_off": "调试模式：已关闭"
   },
   "history": {
     "panel_title": "对话列表",
@@ -54,5 +56,25 @@
     "url_placeholder": "输入网址",
     "navigate": "导航",
     "loading": "正在加载浏览器..."
+  },
+  "tools": {
+    "navigate": "正在访问网页",
+    "click": "正在点击",
+    "type_text": "正在输入",
+    "scroll": "正在滚动",
+    "snapshot": "正在分析页面",
+    "request_human_assistance": "等待您的确认",
+    "go_back": "正在返回上一页",
+    "go_forward": "正在前进",
+    "wait": "正在等待",
+    "new_tab": "正在打开新标签页",
+    "switch_tab": "正在切换标签页",
+    "close_tab": "正在关闭标签页",
+    "finish_task": "完成任务",
+    "default": "正在执行操作"
+  },
+  "status": {
+    "thinking": "正在思考...",
+    "completed": "完成思考"
   }
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -11,12 +11,14 @@ export default {
         serif: ['Noto Serif SC', 'Source Han Serif', 'Songti SC', 'ui-serif', 'Georgia', 'serif'],
       },
       colors: {
-        background: '#FDFBF7', // warm beige / off-white
+        background: '#FDFBF7',
       },
       boxShadow: {
         'soft': '0 20px 40px -15px rgba(0, 0, 0, 0.05)',
       }
     },
   },
-  plugins: [],
+  plugins: [
+    require('@tailwindcss/typography'),
+  ],
 }


### PR DESCRIPTION
<html><head></head><body><hr><h3>📌 摘要</h3><p>当前前端消息卡片主要面向开发者展示技术细节（如 <em>"Agent is thinking..."</em>、<em>"Executing action..."</em>），对普通用户不够友好。</p><p>本次更新引入 <strong>Debug 模式切换</strong>，在非 Debug 模式下优化消息展示体验，并支持 <strong>Markdown 渲染</strong>，提升整体可读性与用户体验。</p><hr><h3>🚀 改动详情</h3><h4>✨ 新增功能</h4><ul><li><p><strong>Debug 模式切换</strong></p><ul><li><p>左下角新增 🐞 按钮</p></li><li><p>支持一键切换 Debug / 用户模式</p></li><li><p>状态持久化至 <code inline="">localStorage</code></p></li></ul></li><li><p><strong>消息卡片优化</strong></p><ul><li><p>思考状态：显示 AI 头像 +「正在思考...」</p></li><li><p>工具调用：显示 AI 头像 + 友好描述（如「正在访问网页」「正在点击」等）</p></li><li><p>工具调用结束：自动更新为「完成思考」</p></li></ul></li><li><p><strong>Markdown 渲染支持</strong></p><ul><li><p>AI 回复支持 Markdown 格式（代码块 / 列表 / 链接等）</p></li></ul></li></ul><hr><h4>⚡ 优化</h4><ul><li><p>非 Debug 模式下隐藏技术性信息（如 WebSocket、上下文压缩等）</p></li><li><p>工具名称支持中英文国际化</p></li></ul><hr><h3>📂 变更文件</h3>

文件路径 | 说明
-- | --
frontend/src/composables/useDebugMode.ts | 新增 Debug 模式状态管理
frontend/src/App.vue | 重构消息渲染逻辑，支持 Markdown
frontend/src/components/Sidebar.vue | 添加 Debug 切换按钮
frontend/src/locales/zh.json | 新增工具名称及状态翻译
frontend/src/locales/en.json | 新增工具名称及状态翻译
frontend/tailwind.config.js | 引入 typography 插件
frontend/package.json | 新增 marked、@tailwindcss/typography 依赖

<hr><h3>✅ 测试项</h3><ul class="contains-task-list"><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> Debug 按钮切换正常（含持久化）</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> 思考状态展示正确</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> 工具调用显示友好名称</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> 工具结束后正确显示「完成思考」</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> Markdown 渲染正常</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> 中英文切换正常</p></li></ul><hr></body></html>

**Debug开启**
<img width="1463" height="820" alt="截屏2026-03-19 20 27 35" src="https://github.com/user-attachments/assets/e9a88370-e420-4abb-846d-421a18408749" />

**正常模式**
<img width="1456" height="818" alt="截屏2026-03-19 20 29 04" src="https://github.com/user-attachments/assets/044ec2cb-4534-4d8e-a790-2f89cab38c1b" />
<img width="1457" height="827" alt="截屏2026-03-19 20 30 10" src="https://github.com/user-attachments/assets/ad7e7a0e-3c10-43ec-b903-d23f21f0456e" />
