### PR TITLE
feat: 添加思考链折叠、消息国际化

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -5,6 +5,7 @@ import { marked } from 'marked'
 import Sidebar from './components/Sidebar.vue'
 import MainInput from './components/MainInput.vue'
 import BrowserView from './components/BrowserView.vue'
+import ThinkingChain from './components/ThinkingChain.vue'
 import { useChatHistory } from './composables/useChatHistory'
 import { useDebugMode } from './composables/useDebugMode'
 
@@ -109,12 +110,8 @@ function isToolCallMessage(msg: any): boolean {
          (msg.message && msg.message.startsWith('Executing action:'))
 }
 
-function isTechMessage(msg: any): boolean {
-  return isThinkingMessage(msg) || isToolCallMessage(msg) || isHiddenMessage(msg)
-}
-
 function isHiddenMessage(msg: any): boolean {
-  const hiddenKeys = ['common.connected_ws', 'common.context_compressing', 'common.manual_compressing', 'common.agent_resumed', 'common.sent_resume']
+  const hiddenKeys = ['common.connected_ws', 'common.context_compressing', 'common.manual_compressing', 'common.agent_resumed', 'common.sent_resume', 'common.message_queued']
   if (hiddenKeys.includes(msg.message_key)) return true
   if (msg.message === 'Connected to NeoFish Agent WebSocket') return true
   if (msg.message && msg.message.includes('Context threshold reached')) return true
@@ -135,21 +132,125 @@ function getToolDisplayName(toolName: string): string {
   return translated === key ? t('tools.default') : translated
 }
 
+function translateMessageFallback(msg: string): { message_key?: string; params?: Record<string, any> } {
+  if (msg === '[Takeover] Browser opened for manual interaction.') {
+    return { message_key: 'common.takeover_browser_opened' }
+  }
+  if (msg.startsWith('[Takeover Ended] Resumed at:')) {
+    const urlMatch = msg.match(/Resumed at: (.+)/)
+    return { message_key: 'common.takeover_ended_message', params: { url: urlMatch ? urlMatch[1] : '' } }
+  }
+  if (msg.startsWith('[Action Required]')) {
+    return { message_key: 'common.action_required_prefix' }
+  }
+  if (msg.startsWith('Agent starting task:')) {
+    const task = msg.replace('Agent starting task: ', '')
+    return { message_key: 'common.agent_starting', params: { task } }
+  }
+  if (msg === 'Agent paused for manual takeover. Waiting for you to finish…') {
+    return { message_key: 'common.agent_paused_for_takeover' }
+  }
+  return {}
+}
+
 function renderMarkdown(text: string): string {
   return marked.parse(text) as string
 }
 
-function pushMessage(data: any) {
-  if (!isHiddenMessage(data) && !isTechMessage(data)) {
-    for (let i = messages.value.length - 1; i >= 0; i--) {
-      const msg = messages.value[i]
-      if (isToolCallMessage(msg) && !msg._completed) {
-        msg._completed = true
-      } else if (!isTechMessage(msg)) {
-        break
+interface ThinkingStep {
+  type: 'thinking' | 'tool'
+  content: string
+  completed: boolean
+}
+
+interface ProcessedMessage {
+  type: string
+  message?: string
+  message_key?: string
+  params?: Record<string, any>
+  images?: string[]
+  files?: { name: string; data: string; type: string }[]
+  image?: string
+  description?: string
+  reason?: string
+  final_url?: string
+  mime_type?: string
+  data?: string
+  filename?: string
+  thinkingChain?: {
+    steps: ThinkingStep[]
+    isActive: boolean
+  }
+}
+
+const processedMessages = computed(() => {
+  if (debugMode.value) {
+    return messages.value.map(msg => ({ ...msg }))
+  }
+  
+  const result: ProcessedMessage[] = []
+  let currentChain: { steps: ThinkingStep[]; startIdx: number } | null = null
+  
+  for (let i = 0; i < messages.value.length; i++) {
+    const msg = messages.value[i]
+    
+    if (isHiddenMessage(msg)) continue
+    
+    if (isThinkingMessage(msg) || isToolCallMessage(msg)) {
+      if (!currentChain) {
+        currentChain = { steps: [], startIdx: i }
       }
+      
+      if (isThinkingMessage(msg)) {
+        currentChain.steps.push({
+          type: 'thinking',
+          content: t('status.thinking'),
+          completed: false
+        })
+      } else {
+        currentChain.steps.push({
+          type: 'tool',
+          content: getToolDisplayName(getToolName(msg) || ''),
+          completed: false
+        })
+        if (currentChain.steps.length > 1) {
+          const prevStep = currentChain.steps[currentChain.steps.length - 2]
+          if (prevStep) prevStep.completed = true
+        }
+      }
+    } else {
+      if (currentChain) {
+        if (currentChain.steps.length > 0) {
+          const lastStep = currentChain.steps[currentChain.steps.length - 1]
+          if (lastStep) lastStep.completed = true
+        }
+        result.push({
+          type: 'thinking_chain',
+          thinkingChain: {
+            steps: currentChain.steps,
+            isActive: false
+          }
+        })
+        currentChain = null
+      }
+      result.push({ ...msg })
     }
   }
+  
+  if (currentChain && currentChain.steps.length > 0) {
+    result.push({
+      type: 'thinking_chain',
+      thinkingChain: {
+        steps: currentChain.steps,
+        isActive: true
+      }
+    })
+  }
+  
+  return result
+})
+
+function pushMessage(data: any) {
   messages.value.push(data)
   if (activeChatId.value && (data.type === 'info' || data.type === 'user')) {
     const preview = (data.message || '').slice(0, 80)
@@ -187,9 +288,13 @@ async function switchToSession(id: string) {
             image: m.image_data
           }
         } else if (m.content.startsWith('[Takeover Ended]')) {
+          const urlMatch = m.content.match(/Resumed at: (.+)/)
           return {
             type: 'takeover_ended',
             message: m.content.replace('[Takeover Ended] ', ''),
+            message_key: 'common.takeover_ended_message',
+            params: { url: urlMatch ? urlMatch[1] : '' },
+            final_url: urlMatch ? urlMatch[1] : '',
             image: m.image_data
           }
         }
@@ -197,6 +302,8 @@ async function switchToSession(id: string) {
       return {
         type: m.role === 'user' ? 'user' : 'info',
         message: m.content,
+        message_key: m.message_key || translateMessageFallback(m.content).message_key,
+        params: m.params || translateMessageFallback(m.content).params,
         images: m.images ?? [],
       }
     })
@@ -333,12 +440,19 @@ onUnmounted(() => {
       <div v-else class="flex-1 flex flex-col max-w-4xl mx-auto w-full pt-20 pb-6 px-4 min-h-0">
         <!-- Chat history stream -->
         <div ref="scrollContainer" class="flex-1 overflow-y-auto space-y-6 pb-20 custom-scrollbar pr-4">
-          <div v-for="(msg, idx) in messages" :key="idx" 
-               class="p-4 rounded-2xl max-w-[85%] animate-fade-in-up"
-               :class="msg.type === 'user' ? 'bg-neutral-100 text-neutral-800 ml-auto rounded-tr-sm' : 'bg-white border border-neutral-100 shadow-sm mr-auto rounded-tl-sm'">
+          <div v-for="(msg, idx) in processedMessages" :key="idx" 
+               class="max-w-[85%] animate-fade-in-up"
+               :class="msg.type === 'user' ? 'bg-neutral-100 text-neutral-800 ml-auto rounded-tr-sm p-4 rounded-2xl' : (msg.type === 'thinking_chain' ? 'mr-auto w-full' : 'bg-white border border-neutral-100 shadow-sm mr-auto rounded-tl-sm p-4 rounded-2xl')">
             
-            <div v-if="msg.type === 'user'" class="flex flex-col gap-2">
-              <!-- Attached images -->
+            <!-- Thinking Chain -->
+            <ThinkingChain 
+              v-if="msg.type === 'thinking_chain'"
+              :steps="msg.thinkingChain?.steps || []"
+              :isActive="msg.thinkingChain?.isActive || false"
+            />
+            
+            <!-- User message -->
+            <div v-else-if="msg.type === 'user'" class="flex flex-col gap-2">
               <div v-if="msg.images && msg.images.length > 0" class="flex flex-wrap gap-2">
                 <img
                   v-for="(src, i) in msg.images"
@@ -348,7 +462,6 @@ onUnmounted(() => {
                   alt="attached image"
                 />
               </div>
-              <!-- Attached files -->
               <div v-if="msg.files && msg.files.length > 0" class="flex flex-wrap gap-2">
                 <div
                   v-for="(file, i) in msg.files"
@@ -361,37 +474,19 @@ onUnmounted(() => {
               <div v-if="msg.message" class="text-[15px] leading-relaxed">{{ msg.message }}</div>
             </div>
             
+            <!-- Info message (AI response) -->
             <div v-else-if="msg.type === 'info'" class="flex gap-3">
-              <template v-if="isHiddenMessage(msg) && !debugMode"></template>
-              <template v-else-if="isThinkingMessage(msg) && !debugMode">
-                <div class="w-6 h-6 rounded-full bg-neutral-900 flex-shrink-0 flex items-center justify-center">
-                  <span class="text-white text-[10px] font-bold">AI</span>
-                </div>
-                <div class="text-[15px] leading-relaxed text-neutral-700 font-serif">
-                  {{ $t('status.thinking') }}
-                </div>
-              </template>
-              <template v-else-if="isToolCallMessage(msg) && !debugMode">
-                <div class="w-6 h-6 rounded-full bg-neutral-900 flex-shrink-0 flex items-center justify-center">
-                  <span class="text-white text-[10px] font-bold">AI</span>
-                </div>
-                <div class="text-[15px] leading-relaxed text-neutral-700 font-serif">
-                  {{ msg._completed ? $t('status.completed') : getToolDisplayName(getToolName(msg) || '') }}
-                </div>
-              </template>
-              <template v-else>
-                <div class="w-6 h-6 rounded-full bg-neutral-900 flex-shrink-0 flex items-center justify-center">
-                  <span class="text-white text-[10px] font-bold">AI</span>
-                </div>
-                <div 
-                  class="text-[15px] leading-relaxed text-neutral-700 font-serif prose prose-sm prose-neutral max-w-none"
-                  v-html="renderMarkdown(msg.message_key ? $t(msg.message_key, msg.params || {}) : msg.message)"
-                ></div>
-              </template>
+              <div class="w-6 h-6 rounded-full bg-neutral-900 flex-shrink-0 flex items-center justify-center">
+                <span class="text-white text-[10px] font-bold">AI</span>
+              </div>
+              <div 
+                class="text-[15px] leading-relaxed text-neutral-700 font-serif prose prose-sm prose-neutral max-w-none"
+                v-html="renderMarkdown(msg.message_key ? $t(msg.message_key, msg.params || {}) : msg.message || '')"
+              ></div>
             </div>
 
             <!-- Takeover started notification -->
-            <div v-else-if="msg.type === 'takeover_started'" class="flex flex-col gap-3 w-full">
+            <div v-else-if="msg.type === 'takeover_started'" class="flex flex-col gap-3 w-full p-4 bg-white border border-neutral-100 shadow-sm rounded-2xl rounded-tl-sm">
               <div class="flex gap-3">
                 <div class="w-6 h-6 rounded-full bg-amber-500 flex-shrink-0 flex items-center justify-center shadow-sm">
                   <span class="text-white text-[11px] font-bold">↗</span>
@@ -402,15 +497,14 @@ onUnmounted(() => {
               </div>
             </div>
 
-            <!-- Takeover ended notification (with final screenshot) -->
-            <div v-else-if="msg.type === 'takeover_ended'" class="flex flex-col gap-3 w-full">
+            <!-- Takeover ended notification -->
+            <div v-else-if="msg.type === 'takeover_ended'" class="flex flex-col gap-3 w-full p-4 bg-white border border-neutral-100 shadow-sm rounded-2xl rounded-tl-sm">
               <div class="flex gap-3">
                 <div class="w-6 h-6 rounded-full bg-green-600 flex-shrink-0 flex items-center justify-center shadow-sm">
                   <span class="text-white text-[11px] font-bold">✓</span>
                 </div>
                 <div class="text-[15px] leading-relaxed text-neutral-700 font-medium pt-0.5">
-                  {{ msg.message_key ? $t(msg.message_key) : msg.message }}
-                  <span v-if="msg.final_url" class="block text-xs text-neutral-400 mt-0.5 font-mono">{{ msg.final_url }}</span>
+                  {{ msg.message_key ? $t(msg.message_key, msg.params || {}) : msg.message }}
                 </div>
               </div>
               <div v-if="msg.image" class="mt-1 rounded-xl overflow-hidden border border-neutral-200/60 shadow-sm bg-neutral-50/50 p-2">
@@ -418,7 +512,8 @@ onUnmounted(() => {
               </div>
             </div>
 
-            <div v-else-if="msg.type === 'image'" class="flex flex-col gap-3 w-full">
+            <!-- Image message -->
+            <div v-else-if="msg.type === 'image'" class="flex flex-col gap-3 w-full p-4 bg-white border border-neutral-100 shadow-sm rounded-2xl rounded-tl-sm">
               <div class="flex gap-3">
                 <div class="w-6 h-6 rounded-full bg-neutral-900 flex-shrink-0 flex items-center justify-center">
                   <span class="text-white text-[10px] font-bold">AI</span>
@@ -430,8 +525,8 @@ onUnmounted(() => {
               </div>
             </div>
 
-            <!-- File message from agent -->
-            <div v-else-if="msg.type === 'file'" class="flex flex-col gap-3 w-full">
+            <!-- File message -->
+            <div v-else-if="msg.type === 'file'" class="flex flex-col gap-3 w-full p-4 bg-white border border-neutral-100 shadow-sm rounded-2xl rounded-tl-sm">
               <div class="flex gap-3">
                 <div class="w-6 h-6 rounded-full bg-neutral-900 flex-shrink-0 flex items-center justify-center">
                   <span class="text-white text-[10px] font-bold">AI</span>
@@ -455,7 +550,8 @@ onUnmounted(() => {
               </a>
             </div>
 
-            <div v-else-if="msg.type === 'action_required'" class="flex flex-col gap-4 w-full">
+            <!-- Action required -->
+            <div v-else-if="msg.type === 'action_required'" class="flex flex-col gap-4 w-full p-4 bg-white border border-neutral-100 shadow-sm rounded-2xl rounded-tl-sm">
               <div class="flex gap-3">
                 <div class="w-6 h-6 rounded-full bg-orange-500 flex-shrink-0 flex items-center justify-center shadow-sm">
                   <span class="text-white text-[12px] font-bold">!</span>
@@ -468,14 +564,12 @@ onUnmounted(() => {
                 <img :src="'data:image/jpeg;base64,' + msg.image" class="w-full h-auto object-contain max-h-[400px] rounded-lg" alt="Action Required" />
               </div>
               <div class="flex flex-wrap gap-3 mt-1">
-                <!-- Take Control: opens embedded browser for direct user interaction -->
                 <button
                   @click="requestTakeover"
                   class="px-6 py-2.5 bg-amber-500 text-white rounded-xl hover:bg-amber-600 transition-all font-medium text-sm shadow-md active:scale-95"
                 >
                   {{ $t('common.takeover_button') }}
                 </button>
-                <!-- Resume: plain signal without opening browser -->
                 <button @click="resumeAgent" class="px-6 py-2.5 bg-neutral-900 text-white rounded-xl hover:bg-neutral-800 transition-all font-medium text-sm shadow-md active:scale-95">
                   {{ $t('common.resume_button') }}
                 </button>

--- a/frontend/src/components/ChatHistoryPanel.vue
+++ b/frontend/src/components/ChatHistoryPanel.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref } from 'vue'
 import { Plus, Trash2, Pencil, Check, X, MessageSquare } from 'lucide-vue-next'
 import { useChatHistory, type ChatSession } from '../composables/useChatHistory'
 import { useI18n } from 'vue-i18n'

--- a/frontend/src/components/MainInput.vue
+++ b/frontend/src/components/MainInput.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref } from 'vue'
 import { Plus, ArrowUp, FileText, Globe, X, File, Image, FileVideo, FileAudio } from 'lucide-vue-next'
 
 const props = defineProps<{

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -5,7 +5,7 @@ import { useI18n } from 'vue-i18n'
 import ChatHistoryPanel from './ChatHistoryPanel.vue'
 import { useDebugMode } from '../composables/useDebugMode'
 
-const { locale, t } = useI18n()
+const { locale } = useI18n()
 const { debugMode, toggleDebug } = useDebugMode()
 const emit = defineEmits<{
   (e: 'new-chat'): void

--- a/frontend/src/components/ThinkingChain.vue
+++ b/frontend/src/components/ThinkingChain.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { ChevronDown, ChevronRight, Brain } from 'lucide-vue-next'
+
+interface Step {
+  type: 'thinking' | 'tool'
+  content: string
+  completed: boolean
+}
+
+const props = defineProps<{
+  steps: Step[]
+  isActive: boolean
+}>()
+
+const { t } = useI18n()
+const expanded = ref(false)
+
+const currentStep = computed(() => {
+  if (props.steps.length === 0) return null
+  return props.steps[props.steps.length - 1]
+})
+
+const completedCount = computed(() => {
+  return props.steps.filter(s => s.completed).length
+})
+
+const summaryText = computed(() => {
+  if (props.isActive && currentStep.value) {
+    return currentStep.value.content
+  }
+  return t('thinking.completed', { count: completedCount.value })
+})
+
+function toggle() {
+  expanded.value = !expanded.value
+}
+</script>
+
+<template>
+  <div class="thinking-chain bg-neutral-50 border border-neutral-200/60 rounded-xl overflow-hidden">
+    <button
+      @click="toggle"
+      class="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-neutral-100/50 transition-colors"
+    >
+      <div class="w-6 h-6 rounded-full bg-neutral-900 flex-shrink-0 flex items-center justify-center">
+        <Brain :size="14" class="text-white" />
+      </div>
+      
+      <span class="flex-1 text-sm text-neutral-600 truncate">
+        {{ summaryText }}
+      </span>
+      
+      <span v-if="!isActive" class="text-xs text-neutral-400 mr-2">
+        {{ completedCount }} {{ $t('thinking.steps') }}
+      </span>
+      
+      <ChevronRight v-if="!expanded" :size="16" class="text-neutral-400" />
+      <ChevronDown v-else :size="16" class="text-neutral-400" />
+    </button>
+    
+    <Transition
+      enter-active-class="transition-all duration-200 ease-out"
+      leave-active-class="transition-all duration-150 ease-in"
+      enter-from-class="opacity-0 max-h-0"
+      leave-to-class="opacity-0 max-h-0"
+    >
+      <div v-if="expanded" class="border-t border-neutral-200/60 overflow-hidden" style="max-height: 400px;">
+        <div class="px-4 py-3 space-y-2">
+          <div
+            v-for="(step, idx) in steps"
+            :key="idx"
+            class="flex items-center gap-2 text-sm"
+            :class="step.completed ? 'text-neutral-500' : 'text-neutral-800'"
+          >
+            <span v-if="step.completed" class="text-green-500">✓</span>
+            <span v-else class="text-neutral-400">○</span>
+            <span>{{ step.content }}</span>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </div>
+</template>

--- a/frontend/src/composables/useChatHistory.ts
+++ b/frontend/src/composables/useChatHistory.ts
@@ -13,6 +13,9 @@ export interface ChatMessage {
   content: string
   timestamp: string
   images?: string[]
+  image_data?: string
+  message_key?: string
+  params?: Record<string, any>
 }
 
 const BASE = 'http://localhost:8000'

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -3,11 +3,14 @@
     "agent_ready": "Agent Ready",
     "connecting": "Connecting...",
     "action_required": "Action Required",
+    "action_required_prefix": "Action Required",
     "resume_button": "I've processed it, continue",
     "takeover_button": "Take Control",
     "takeover_done_button": "Done",
     "takeover_started": "Browser embedded — interact directly in the page",
+    "takeover_browser_opened": "Browser opened for manual interaction",
     "takeover_ended": "Takeover ended. AI is resuming…",
+    "takeover_ended_message": "Takeover ended, resuming at: {url}",
     "takeover_already_active": "Takeover is already in progress.",
     "takeover_banner": "Browser embedded — interact directly",
     "proactive_takeover": "Take Over",
@@ -76,5 +79,10 @@
   "status": {
     "thinking": "Thinking...",
     "completed": "Finished thinking"
+  },
+  "thinking": {
+    "process": "Thinking Process",
+    "completed": "Completed · {count} steps",
+    "steps": "steps"
   }
 }

--- a/frontend/src/locales/zh.json
+++ b/frontend/src/locales/zh.json
@@ -3,11 +3,14 @@
     "agent_ready": "代理就绪",
     "connecting": "正在连接...",
     "action_required": "需要您的协助",
+    "action_required_prefix": "需要您的协助",
     "resume_button": "我已处理完毕，继续执行",
     "takeover_button": "接管浏览器",
     "takeover_done_button": "完成操作",
     "takeover_started": "浏览器已嵌入页面，您可在此直接操作",
+    "takeover_browser_opened": "浏览器已打开，您可以手动操作",
     "takeover_ended": "接管结束，AI 正在继续执行…",
+    "takeover_ended_message": "接管结束，继续执行于：{url}",
     "takeover_already_active": "接管操作正在进行中。",
     "takeover_banner": "浏览器已嵌入，您可直接操作",
     "proactive_takeover": "手动接管",
@@ -76,5 +79,10 @@
   "status": {
     "thinking": "正在思考...",
     "completed": "完成思考"
+  },
+  "thinking": {
+    "process": "思考过程",
+    "completed": "已完成 · {count} 步",
+    "steps": "步"
   }
 }

--- a/platforms/web.py
+++ b/platforms/web.py
@@ -91,12 +91,16 @@ class WebAdapter(PlatformAdapter):
 
     async def start(self) -> None:
         """Send the initial "connected" info frame to the client."""
-        await self._ws.send_text(json.dumps({
-            "type": "info",
-            "message": "Connected to NeoFish Agent WebSocket",
-            "message_key": "common.connected_ws",
-            "session_id": self._session_id,
-        }))
+        await self._ws.send_text(
+            json.dumps(
+                {
+                    "type": "info",
+                    "message": "Connected to NeoFish Agent WebSocket",
+                    "message_key": "common.connected_ws",
+                    "session_id": self._session_id,
+                }
+            )
+        )
 
     async def stop(self) -> None:
         """No-op: WebSocket lifecycle is managed by FastAPI."""
@@ -187,10 +191,13 @@ class WebAdapter(PlatformAdapter):
         content: str,
         images: list = None,
         image_data: str = "",
+        message_key: str = "",
+        params: dict = None,
     ) -> None:
-        """Append a message to the session store and persist to disk."""
         if images is None:
             images = []
+        if params is None:
+            params = {}
         msg: dict = {
             "role": role,
             "content": content,
@@ -199,8 +206,11 @@ class WebAdapter(PlatformAdapter):
         }
         if image_data:
             msg["image_data"] = image_data
+        if message_key:
+            msg["message_key"] = message_key
+        if params:
+            msg["params"] = params
         self._sessions[self._session_id]["messages"].append(msg)
-        # Auto-title: use the first user message (truncated)
         if role == "user" and not self._sessions[self._session_id]["title"]:
             self._sessions[self._session_id]["title"] = (content or "📷 Image")[:40]
         self._save_sessions()
@@ -213,7 +223,9 @@ class WebAdapter(PlatformAdapter):
             "image": b64_image,
         }
         await self._ws.send_text(json.dumps(payload))
-        self._append_message("assistant", f"[Image] {description}", image_data=b64_image)
+        self._append_message(
+            "assistant", f"[Image] {description}", image_data=b64_image
+        )
 
     def _build_history(self) -> list:
         """Build the conversation history list for the agent (excludes last msg)."""
@@ -223,12 +235,14 @@ class WebAdapter(PlatformAdapter):
             role = m.get("role", "user")
             content = m.get("content", "")
             if role == "user":
-                history.append({"role": "user", "content": content or "(user sent an image)"})
+                history.append(
+                    {"role": "user", "content": content or "(user sent an image)"}
+                )
             else:
                 clean = content
                 for prefix in _ASSISTANT_MSG_PREFIXES:
                     if clean.startswith(prefix):
-                        clean = clean[len(prefix):]
+                        clean = clean[len(prefix) :]
                 if clean:
                     history.append({"role": "assistant", "content": clean})
         return history
@@ -269,19 +283,27 @@ class WebAdapter(PlatformAdapter):
 
     async def _handle_resume(self) -> None:
         self._pm.resume_from_human()
-        await self._ws.send_text(json.dumps({
-            "type": "info",
-            "message": "Agent resumed execution.",
-            "message_key": "common.agent_resumed",
-        }))
+        await self._ws.send_text(
+            json.dumps(
+                {
+                    "type": "info",
+                    "message": "Agent resumed execution.",
+                    "message_key": "common.agent_resumed",
+                }
+            )
+        )
 
     async def _handle_takeover(self) -> None:
         if self._pm.in_takeover:
-            await self._ws.send_text(json.dumps({
-                "type": "info",
-                "message": "Takeover is already in progress.",
-                "message_key": "common.takeover_already_active",
-            }))
+            await self._ws.send_text(
+                json.dumps(
+                    {
+                        "type": "info",
+                        "message": "Takeover is already in progress.",
+                        "message_key": "common.takeover_already_active",
+                    }
+                )
+            )
             return
 
         self._pm.request_pause()
@@ -297,18 +319,25 @@ class WebAdapter(PlatformAdapter):
 
             initial_screenshot = await self._pm.get_page_screenshot_base64()
 
-            await self._ws.send_text(json.dumps({
-                "type": "takeover_started",
-                "message": "Browser embedded for manual interaction.",
-                "message_key": "common.takeover_started",
-                "url": current_url,
-                "image": initial_screenshot,
-                "viewport": {
-                    "width": self._pm.viewport_width,
-                    "height": self._pm.viewport_height,
-                },
-            }))
-            self._append_message("assistant", "[Takeover] Browser opened for manual interaction.")
+            await self._ws.send_text(
+                json.dumps(
+                    {
+                        "type": "takeover_started",
+                        "message": "Browser embedded for manual interaction.",
+                        "message_key": "common.takeover_started",
+                        "url": current_url,
+                        "image": initial_screenshot,
+                        "viewport": {
+                            "width": self._pm.viewport_width,
+                            "height": self._pm.viewport_height,
+                        },
+                    }
+                )
+            )
+            self._append_message(
+                "assistant",
+                "[Takeover] Browser opened for manual interaction.",
+            )
 
             # Mark as in takeover and create the completion event.
             done_event = self._pm.begin_embedded_takeover()
@@ -316,11 +345,15 @@ class WebAdapter(PlatformAdapter):
             # Stream screenshots to the frontend.
             async def send_frame(screenshot_b64: str, url: str) -> None:
                 try:
-                    await self._ws.send_text(json.dumps({
-                        "type": "takeover_frame",
-                        "image": screenshot_b64,
-                        "url": url,
-                    }))
+                    await self._ws.send_text(
+                        json.dumps(
+                            {
+                                "type": "takeover_frame",
+                                "image": screenshot_b64,
+                                "url": url,
+                            }
+                        )
+                    )
                 except Exception as e:
                     print(f"Takeover frame send error: {e}")
 
@@ -409,17 +442,23 @@ class WebAdapter(PlatformAdapter):
         if self._session_id in _web_running:
             if self._session_id not in _web_queues:
                 _web_queues[self._session_id] = asyncio.Queue()
-            await _web_queues[self._session_id].put({
-                "text": user_msg,
-                "images": user_images,
-                "files": user_files,
-            })
+            await _web_queues[self._session_id].put(
+                {
+                    "text": user_msg,
+                    "images": user_images,
+                    "files": user_files,
+                }
+            )
             # Inform the user
-            await self._ws.send_text(json.dumps({
-                "type": "info",
-                "message": "Message queued (agent is busy).",
-                "message_key": "common.message_queued",
-            }))
+            await self._ws.send_text(
+                json.dumps(
+                    {
+                        "type": "info",
+                        "message": "Message queued (agent is busy).",
+                        "message_key": "common.message_queued",
+                    }
+                )
+            )
             return
 
         # Save uploaded images to workspace and collect paths
@@ -430,7 +469,9 @@ class WebAdapter(PlatformAdapter):
                 media_type = header.split(":")[1].split(";")[0]
                 ext = media_type.split("/")[1] if "/" in media_type else "bin"
                 ext = ext.replace("+xml", "")
-                filename = f"upload_{datetime.now().strftime('%Y%m%d_%H%M%S')}_{i}.{ext}"
+                filename = (
+                    f"upload_{datetime.now().strftime('%Y%m%d_%H%M%S')}_{i}.{ext}"
+                )
                 filepath = self._uploads_dir / filename
                 filepath.write_bytes(base64.b64decode(b64_data))
                 saved_paths.append(str(filepath))
@@ -453,14 +494,19 @@ class WebAdapter(PlatformAdapter):
                 saved_paths.append(str(filepath))
                 logger.info("Saved uploaded file: %s", filepath)
             except Exception as e:
-                logger.warning("Failed to save uploaded file %s: %s", file_data.get("name"), e)
+                logger.warning(
+                    "Failed to save uploaded file %s: %s", file_data.get("name"), e
+                )
 
         self._append_message("user", user_msg, images=user_images)
 
         # Dispatch to on_message callback if set (allows external orchestration)
         if self.on_message is not None:
             attachments = [(f"image_{i}", du) for i, du in enumerate(user_images)]
-            attachments.extend((f.get("name", f"file_{i}"), f.get("data", "")) for i, f in enumerate(user_files))
+            attachments.extend(
+                (f.get("name", f"file_{i}"), f.get("data", ""))
+                for i, f in enumerate(user_files)
+            )
             unified = UnifiedMessage(
                 platform="web",
                 user_id="web_user",
@@ -476,10 +522,16 @@ class WebAdapter(PlatformAdapter):
             if isinstance(msg, dict):
                 human_text = msg.get("message", "")
                 packet = {"type": "info", **msg}
+                self._append_message(
+                    "assistant",
+                    human_text,
+                    message_key=msg.get("message_key", ""),
+                    params=msg.get("params"),
+                )
             else:
                 human_text = str(msg)
                 packet = {"type": "info", "message": human_text}
-            self._append_message("assistant", human_text)
+                self._append_message("assistant", human_text)
             await self._ws.send_text(json.dumps(packet))
 
         # Mark as running
@@ -491,7 +543,9 @@ class WebAdapter(PlatformAdapter):
                     self._pm,
                     user_msg,
                     _ws_send_msg,
-                    lambda reason, img: self.request_action(self._session_id, reason, img),
+                    lambda reason, img: self.request_action(
+                        self._session_id, reason, img
+                    ),
                     self._send_image,
                     lambda path, desc: self.send_file(self._session_id, path, desc),
                     images=user_images,


### PR DESCRIPTION
- 新增 ThinkingChain 组件，合并显示思考+工具调用，支持展开/折叠
- 后端保存 message_key 和 params，支持历史消息国际化翻译
- 非 Debug 模式下隐藏技术性消息
- 补全 ChatMessage 类型定义（image_data、message_key、params）
- 移除未使用的导入

<img width="1456" height="818" alt="截屏2026-03-20 11 53 07" src="https://github.com/user-attachments/assets/af4ac3e3-8341-4496-803e-73770b0a8470" />



<img width="1462" height="826" alt="截屏2026-03-20 11 08 58" src="https://github.com/user-attachments/assets/e4e27850-e75e-498b-a5fa-f65d7c3bf108" />

文件改动详情
1. frontend/src/components/ThinkingChain.vue (新增)
- 新建可折叠的思考链组件
- 接收 steps（步骤列表）和 isActive（是否活跃）属性
- 折叠态显示当前步骤或"已完成 · N 步"
- 展开态显示所有步骤，带 ✓ 标记已完成项
- 使用 Vue Transition 实现展开/折叠动画
2. frontend/src/App.vue
- 引入 ThinkingChain 组件
- 新增 processedMessages computed：将连续的 thinking + tool_call 消息合并为 thinking_chain 类型
- 新增 translateMessageFallback 函数：对旧历史消息推断 message_key 进行翻译
- 新增 isHiddenMessage 函数：判断是否隐藏技术性消息（WebSocket 连接、上下文压缩等）
- 模板渲染逻辑重构，支持 thinking_chain 类型消息
- 历史消息加载时使用 message_key + params 进行翻译
3. frontend/src/composables/useChatHistory.ts
- ChatMessage 接口新增字段：
  - image_data?: string — 图片 base64 数据
  - message_key?: string — 国际化翻译键
  - params?: Record<string, any> — 翻译参数
4. frontend/src/components/Sidebar.vue
- 移除未使用的 t 解构（模板使用 $t()）
5. frontend/src/components/ChatHistoryPanel.vue
- 移除未使用的 computed 导入
6. frontend/src/components/MainInput.vue
- 移除未使用的 computed 导入
7. frontend/src/locales/zh.json
新增翻译：
- thinking.process: "思考过程"
- thinking.completed: "已完成 · {count} 步"
- thinking.steps: "步"
- common.takeover_browser_opened: "浏览器已打开，您可以手动操作"
- common.takeover_ended_message: "接管结束，继续执行于：{url}"
- common.action_required_prefix: "需要您的协助"
8. frontend/src/locales/en.json
同步添加英文翻译
9. platforms/web.py
- _append_message 函数新增 message_key 和 params 参数并保存到消息记录
- _ws_send_msg 函数调用 _append_message 时传递 message_key 和 params
---
