### PR TITLE
Feature/user profile sidebar

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -1,4 +1,3 @@
-import os
 import json
 import asyncio
 import logging
@@ -62,7 +61,90 @@ KEEP_RECENT = 3  # For microcompact
 workspace = WorkspaceManager(WORKDIR, strict=False)
 knowledge_service = KnowledgeService(WORKDIR)
 
-SYSTEM_PROMPT = """You are NeoFish, an autonomous agent that can:
+# ── User Profile ─────────────────────────────────────────────────────────────
+
+PROFILE_FILE = Path("data/user_profile.json")
+PROFILE_FIELDS = [
+    "name", "gender", "age", "occupation",
+    "location", "interests", "language", "timezone", "bio",
+    "phone", "id_card",
+]
+PROFILE_LABELS: dict[str, str] = {
+    "name": "Name",
+    "gender": "Gender",
+    "age": "Age",
+    "occupation": "Occupation",
+    "location": "Location",
+    "interests": "Interests",
+    "language": "Language",
+    "timezone": "Timezone",
+    "bio": "Bio",
+    "phone": "Phone",
+    "id_card": "ID Card",
+}
+PROFILE_DEFAULTS: dict[str, str] = {
+    "language": "Chinese",
+    "timezone": "Asia/Shanghai",
+}
+
+_user_profile: dict[str, str] | None = None
+
+
+def load_user_profile() -> dict[str, str]:
+    global _user_profile
+    if _user_profile is not None:
+        return _user_profile
+    if PROFILE_FILE.exists():
+        try:
+            _user_profile = json.loads(PROFILE_FILE.read_text("utf-8"))
+            return _user_profile
+        except Exception:
+            pass
+    _user_profile = {}
+    return _user_profile
+
+
+def save_user_profile(data: dict[str, str]) -> None:
+    global _user_profile
+    cleaned = {k: str(data.get(k, "")).strip() for k in PROFILE_FIELDS}
+    PROFILE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    PROFILE_FILE.write_text(json.dumps(cleaned, ensure_ascii=False, indent=2), "utf-8")
+    _user_profile = cleaned
+
+
+def is_profile_configured() -> bool:
+    profile = load_user_profile()
+    return any(v.strip() for v in profile.values())
+
+
+def get_user_profile_text() -> str:
+    profile = load_user_profile()
+    lines: list[str] = []
+    for key in PROFILE_FIELDS:
+        value = profile.get(key, "").strip()
+        if not value:
+            value = PROFILE_DEFAULTS.get(key, "")
+        if value:
+            label = PROFILE_LABELS.get(key, key)
+            lines.append(f"- {label}: {value}")
+    if not lines:
+        return "No personal profile has been configured yet."
+    return "\n".join(lines)
+
+
+
+def build_system_prompt() -> str:
+    profile_text = get_user_profile_text()
+    return _SYSTEM_PROMPT_TEMPLATE.format(workdir=WORKDIR, user_profile=profile_text)
+
+
+_SYSTEM_PROMPT_TEMPLATE = """You are NeoFish, an autonomous agent that serves the user described below. Your tone, suggestions, and decisions should be tailored to this person.
+
+## User Profile
+{user_profile}
+
+## Core Capabilities
+You can:
 1. **Browse the web** - Navigate, click, type, extract information
 2. **Manage files** - Read, write, edit files in the workspace
 3. **Execute commands** - Run shell commands (blocking or background)
@@ -144,7 +226,7 @@ pending_tasks: <genuinely unfinished tasks>
 - current_state is the MOST important field - always include it when there's progress.
 - Keep each field concise (1-2 sentences max).
 - If nothing meaningful happened, do not output the block.
-""".format(workdir=WORKDIR)
+"""
 
 TOOLS = [
     # Browser tools
@@ -1495,7 +1577,7 @@ async def run_agent_loop(
         assistant_blocks = await _call_llm_with_retry(
             model_name,
             messages,
-            f"{SYSTEM_PROMPT}\n\n{session_memory.get_all()}",
+            f"{build_system_prompt()}\n\n{session_memory.get_all()}",
             TOOLS,
             emit_info,
         )

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -8,6 +8,7 @@ import BrowserView from './components/BrowserView.vue'
 import ThinkingChain from './components/ThinkingChain.vue'
 import TaskSidebar from './components/TaskSidebar.vue'
 import KnowledgeWorkspace from './components/KnowledgeWorkspace.vue'
+import type { ProfileField } from './components/ProfilePanel.vue'
 import { useChatHistory } from './composables/useChatHistory'
 import { useTasks } from './composables/useTasks'
 import { useDebugMode } from './composables/useDebugMode'
@@ -22,6 +23,24 @@ const { loadFolderFiles } = useKnowledge()
 const { debugMode } = useDebugMode()
 useThemeMode()
 const mainView = ref<'chat' | 'knowledge'>('chat')
+
+// ─── Profile ────────────────────────────────────────────────────────────────
+const DEFAULT_PROFILE_FIELDS: ProfileField[] = [
+  { key: 'name', label: 'Name', default: '' },
+  { key: 'gender', label: 'Gender', default: '' },
+  { key: 'age', label: 'Age', default: '' },
+  { key: 'occupation', label: 'Occupation', default: '' },
+  { key: 'location', label: 'Location', default: '' },
+  { key: 'interests', label: 'Interests', default: '' },
+  { key: 'language', label: 'Language', default: 'Chinese' },
+  { key: 'timezone', label: 'Timezone', default: 'Asia/Shanghai' },
+  { key: 'bio', label: 'Bio', default: '' },
+  { key: 'phone', label: 'Phone', default: '' },
+  { key: 'id_card', label: 'ID Card', default: '' },
+]
+const profileFields = ref<ProfileField[]>([...DEFAULT_PROFILE_FIELDS])
+const currentProfile = ref<Record<string, string>>({})
+const profilePanelOpen = ref(false)
 
 // ─── WebSocket ─────────────────────────────────────────────────────────────
 const ws = ref<WebSocket | null>(null)
@@ -51,6 +70,15 @@ function connectWs(sessionId: string) {
     const data = JSON.parse(event.data)
     if (data.session_id && data.session_id !== activeChatId.value) {
       activeChatId.value = data.session_id
+    }
+    if (data.type === 'profile_required') {
+      profileFields.value = data.fields || []
+      profilePanelOpen.value = true
+      return
+    }
+    if (data.type === 'profile_saved') {
+      profilePanelOpen.value = false
+      return
     }
     if (data.type === 'task_status') {
       isTaskRunning.value = data.status === 'running'
@@ -413,6 +441,13 @@ function stopTask() {
   }
 }
 
+function handleProfileSubmit(profile: Record<string, string>) {
+  currentProfile.value = { ...profile }
+  if (ws.value && isConnected.value) {
+    ws.value.send(JSON.stringify({ type: 'user_profile', profile }))
+  }
+}
+
 /** Request an embedded browser takeover. */
 function requestTakeover() {
   if (ws.value && isConnected.value) {
@@ -487,9 +522,14 @@ onUnmounted(() => {
 <template>
   <div class="theme-app h-screen w-full flex overflow-hidden font-sans">
     <Sidebar
+      :profile-fields="profileFields"
+      :current-profile="currentProfile"
+      :profile-panel-open="profilePanelOpen"
       @new-chat="handleNewChat"
       @select-chat="switchToSession"
       @open-knowledge-workspace="openKnowledgeWorkspace"
+      @save-profile="handleProfileSubmit"
+      @profile-panel-closed="profilePanelOpen = false"
     />
     
     <main class="relative flex h-full min-w-0 flex-1 flex-col">

--- a/frontend/src/components/ProfilePanel.vue
+++ b/frontend/src/components/ProfilePanel.vue
@@ -1,0 +1,154 @@
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+export interface ProfileField {
+  key: string
+  label: string
+  default: string
+}
+
+const props = defineProps<{
+  fields: ProfileField[]
+  currentProfile: Record<string, string>
+}>()
+
+const emit = defineEmits<{
+  save: [profile: Record<string, string>]
+}>()
+
+const { t } = useI18n()
+
+const form = ref<Record<string, string>>({})
+const editing = ref(false)
+const submitting = ref(false)
+
+function initForm() {
+  props.fields.forEach(f => {
+    form.value[f.key] = props.currentProfile[f.key] || f.default || ''
+  })
+}
+
+onMounted(initForm)
+
+const isFormValid = computed(() => {
+  const name = (form.value.name || '').trim()
+  return name.length > 0
+})
+
+const hasProfile = computed(() => {
+  return Object.values(props.currentProfile).some(v => (v || '').trim())
+})
+
+function fieldLabel(key: string, defaultLabel: string): string {
+  const i18nKey = `profile.fields.${key}`
+  const translated = t(i18nKey)
+  return translated === i18nKey ? defaultLabel : translated
+}
+
+function startEdit() {
+  initForm()
+  editing.value = true
+}
+
+function cancelEdit() {
+  editing.value = false
+}
+
+async function handleSave() {
+  if (!isFormValid.value || submitting.value) return
+  submitting.value = true
+  const profile: Record<string, string> = {}
+  props.fields.forEach(f => {
+    profile[f.key] = (form.value[f.key] || '').trim()
+  })
+  emit('save', profile)
+  editing.value = false
+  submitting.value = false
+}
+</script>
+
+<template>
+  <div class="flex h-full flex-col">
+    <!-- Header -->
+    <div class="flex items-center justify-between px-5 py-4 border-b" style="border-color: var(--border-muted);">
+      <h3 class="text-sm font-semibold tracking-wide" style="color: var(--text-primary);">
+        {{ $t('profile.panel_title') }}
+      </h3>
+      <button
+        v-if="hasProfile && !editing"
+        @click="startEdit"
+        class="rounded-lg px-3 py-1 text-xs font-medium transition-colors"
+        style="color: var(--text-secondary); background: var(--surface-soft);"
+      >
+        {{ $t('profile.edit') }}
+      </button>
+    </div>
+
+    <!-- Content -->
+    <div class="flex-1 overflow-y-auto px-5 py-4 theme-scrollbar">
+      <!-- View mode -->
+      <div v-if="hasProfile && !editing" class="space-y-3">
+        <div v-for="field in fields" :key="field.key" class="flex flex-col gap-0.5">
+          <span class="text-[10px] font-semibold uppercase tracking-wider" style="color: var(--text-muted);">
+            {{ fieldLabel(field.key, field.label) }}
+          </span>
+          <span class="text-sm" style="color: var(--text-primary);">
+            {{ currentProfile[field.key] || '—' }}
+          </span>
+        </div>
+      </div>
+
+      <!-- Empty / Edit mode -->
+      <div v-else class="space-y-4">
+        <p v-if="!hasProfile" class="text-sm leading-relaxed" style="color: var(--text-muted);">
+          {{ $t('profile.panel_hint') }}
+        </p>
+
+        <div v-for="field in fields" :key="field.key" class="flex flex-col gap-1">
+          <label class="text-[10px] font-semibold uppercase tracking-wider" style="color: var(--text-muted);">
+            {{ fieldLabel(field.key, field.label) }}
+          </label>
+          <input
+            v-if="field.key !== 'bio'"
+            v-model="form[field.key]"
+            class="theme-input-shell rounded-lg px-3 py-2 text-sm transition-colors outline-none"
+            style="color: var(--text-primary);"
+            :placeholder="fieldLabel(field.key, field.label)"
+            autocomplete="off"
+          />
+          <textarea
+            v-else
+            v-model="form[field.key]"
+            class="theme-input-shell rounded-lg px-3 py-2 text-sm transition-colors outline-none resize-none"
+            style="color: var(--text-primary); min-height: 4rem;"
+            :placeholder="fieldLabel(field.key, field.label)"
+            autocomplete="off"
+          ></textarea>
+        </div>
+      </div>
+    </div>
+
+    <!-- Actions (edit mode only) -->
+    <div v-if="!hasProfile || editing" class="border-t px-5 py-4 space-y-2" style="border-color: var(--border-muted);">
+      <button
+        @click="handleSave"
+        :disabled="!isFormValid || submitting"
+        class="w-full rounded-xl py-2.5 text-sm font-semibold transition-all duration-200 active:scale-[0.98]"
+        :class="isFormValid && !submitting
+          ? 'text-white shadow-lg'
+          : 'cursor-not-allowed opacity-40'"
+        style="background: var(--surface-strong); color: var(--text-contrast);"
+      >
+        {{ submitting ? $t('profile.saving') : $t('profile.save') }}
+      </button>
+      <button
+        v-if="hasProfile"
+        @click="cancelEdit"
+        class="w-full rounded-xl py-2 text-xs font-medium transition-colors theme-button-soft"
+      >
+        {{ $t('profile.cancel') }}
+      </button>
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -1,24 +1,47 @@
 <script setup lang="ts">
-import { ref } from 'vue'
-import { PlaySquare, Settings, Compass, LayoutGrid, Languages, Bug, Moon, SunMedium, BookMarked } from 'lucide-vue-next'
+import { ref, watch } from 'vue'
+import { PlaySquare, Settings, Compass, LayoutGrid, Languages, Bug, Moon, SunMedium, BookMarked, User } from 'lucide-vue-next'
 import { useI18n } from 'vue-i18n'
 import ChatHistoryPanel from './ChatHistoryPanel.vue'
 import GalleryPanel from './GalleryPanel.vue'
 import KnowledgePanel from './KnowledgePanel.vue'
+import ProfilePanel from './ProfilePanel.vue'
+import type { ProfileField } from './ProfilePanel.vue'
 import { useDebugMode } from '../composables/useDebugMode'
 import { useThemeMode } from '../composables/useThemeMode'
 
 const { locale } = useI18n()
 const { debugMode, toggleDebug } = useDebugMode()
 const { isDarkMode, toggleTheme } = useThemeMode()
+
+const props = defineProps<{
+  profileFields: ProfileField[]
+  currentProfile: Record<string, string>
+  profilePanelOpen: boolean
+}>()
+
 const emit = defineEmits<{
   (e: 'new-chat'): void
   (e: 'select-chat', id: string): void
   (e: 'open-knowledge-workspace', folderId: string): void
+  (e: 'save-profile', profile: Record<string, string>): void
+  (e: 'profile-panel-closed'): void
 }>()
 
-const activePanel = ref<'history' | 'gallery' | 'knowledge' | null>(null)
+const activePanel = ref<'history' | 'gallery' | 'knowledge' | 'profile' | null>(null)
 const panelWidth = 'var(--history-panel-width)'
+
+watch(() => props.profilePanelOpen, (val) => {
+  if (val) {
+    activePanel.value = 'profile'
+  }
+})
+
+watch(activePanel, (val) => {
+  if (val !== 'profile') {
+    emit('profile-panel-closed')
+  }
+})
 
 function toggleHistory() {
   activePanel.value = activePanel.value === 'history' ? null : 'history'
@@ -30,6 +53,10 @@ function toggleGallery() {
 
 function toggleKnowledge() {
   activePanel.value = activePanel.value === 'knowledge' ? null : 'knowledge'
+}
+
+function toggleProfile() {
+  activePanel.value = activePanel.value === 'profile' ? null : 'profile'
 }
 
 function toggleLanguage() {
@@ -46,6 +73,10 @@ function handleSelectChat(id: string) {
 
 function handleOpenFolder(folderId: string) {
   emit('open-knowledge-workspace', folderId)
+}
+
+function handleSaveProfile(profile: Record<string, string>) {
+  emit('save-profile', profile)
 }
 </script>
 
@@ -112,8 +143,13 @@ function handleOpenFolder(folderId: string) {
             <Bug :size="20" stroke-width="2" />
           </button>
 
-          <button :title="$t('sidebar.settings')" class="rounded-xl p-2 transition-colors theme-text-muted hover:bg-[var(--surface-soft)] hover:text-[color:var(--text-primary)]">
-            <Settings :size="20" stroke-width="2" />
+          <button
+            @click="toggleProfile"
+            :title="$t('profile.panel_title')"
+            class="rounded-xl p-2 transition-all duration-300"
+            :class="activePanel === 'profile' ? 'theme-button-strong shadow-md' : 'theme-text-muted hover:bg-[var(--surface-soft)] hover:text-[color:var(--text-primary)]'"
+          >
+            <User :size="20" stroke-width="2" />
           </button>
         </div>
       </div>
@@ -134,6 +170,12 @@ function handleOpenFolder(folderId: string) {
           />
           <GalleryPanel v-else-if="activePanel === 'gallery'" />
           <KnowledgePanel v-else-if="activePanel === 'knowledge'" @open-folder="handleOpenFolder" />
+          <ProfilePanel
+            v-else-if="activePanel === 'profile'"
+            :fields="profileFields"
+            :currentProfile="currentProfile"
+            @save="handleSaveProfile"
+          />
         </div>
       </div>
     </div>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -145,6 +145,43 @@
     "select_failed": "Failed to load this knowledge folder.",
     "deselect_failed": "Failed to remove this knowledge folder."
   },
+  "profile": {
+    "panel_title": "Profile",
+    "panel_hint": "Fill in the details below so I can serve you better.",
+    "title": "Let's get to know each other",
+    "subtitle": "Fill in the details below so I can serve you better",
+    "save": "Save",
+    "saving": "Saving...",
+    "edit": "Edit",
+    "cancel": "Cancel",
+    "hint": "You can change these anytime from the sidebar",
+    "fields": {
+      "name": "Name",
+      "gender": "Gender",
+      "age": "Age",
+      "occupation": "Occupation",
+      "location": "Location",
+      "interests": "Interests",
+      "language": "Language",
+      "timezone": "Timezone",
+      "bio": "Bio",
+      "phone": "Phone",
+      "id_card": "ID Card"
+    },
+    "placeholders": {
+      "name": "Your name",
+      "gender": "e.g. Male, Female",
+      "age": "Your age",
+      "occupation": "e.g. Software Engineer, Designer",
+      "location": "e.g. New York, London",
+      "interests": "e.g. Coding, Photography, Music",
+      "language": "e.g. English, Chinese",
+      "timezone": "e.g. America/New_York",
+      "bio": "A few words about yourself...",
+      "phone": "Your phone number",
+      "id_card": "Your ID card number"
+    }
+  },
   "gallery": {
     "title": "Gallery",
     "placeholder": "Gallery panel is preserved. Asset management can be added here."

--- a/frontend/src/locales/zh.json
+++ b/frontend/src/locales/zh.json
@@ -145,6 +145,43 @@
     "select_failed": "加载该知识库失败，请稍后重试。",
     "deselect_failed": "移除该知识库失败，请稍后重试。"
   },
+  "profile": {
+    "panel_title": "个人档案",
+    "panel_hint": "填写以下信息，我会更好地为您服务。",
+    "title": "让我们认识一下",
+    "subtitle": "填写以下信息，我会更好地为您服务",
+    "save": "保存",
+    "saving": "保存中...",
+    "edit": "编辑",
+    "cancel": "取消",
+    "hint": "随时可以在侧面信息栏中修改这些信息",
+    "fields": {
+      "name": "姓名",
+      "gender": "性别",
+      "age": "年龄",
+      "occupation": "职业",
+      "location": "所在地",
+      "interests": "兴趣爱好",
+      "language": "语言",
+      "timezone": "时区",
+      "bio": "个人简介",
+      "phone": "手机号",
+      "id_card": "身份证号"
+    },
+    "placeholders": {
+      "name": "请输入您的姓名",
+      "gender": "如：男、女",
+      "age": "请输入您的年龄",
+      "occupation": "如：软件工程师、设计师",
+      "location": "如：北京、上海",
+      "interests": "如：编程、摄影、音乐",
+      "language": "如：Chinese、English",
+      "timezone": "如：Asia/Shanghai",
+      "bio": "简单介绍一下自己...",
+      "phone": "请输入手机号",
+      "id_card": "请输入身份证号"
+    }
+  },
   "gallery": {
     "title": "图库",
     "placeholder": "图库面板已保留。后续可在这里管理图片素材与引用。"

--- a/main.py
+++ b/main.py
@@ -571,6 +571,37 @@ def cancel_scheduled_task(task_id: str):
     return {"ok": True, "task_id": task_id}
 
 
+
+# ─── User Profile ─────────────────────────────────────────────────────────────
+
+class UserProfileBody(BaseModel):
+    profile: dict[str, str]
+
+
+@app.get("/profile")
+def get_profile():
+    """Return the current user profile."""
+    from agent import load_user_profile, PROFILE_FIELDS, PROFILE_LABELS, PROFILE_DEFAULTS
+    profile = load_user_profile()
+    fields = [
+        {
+            "key": k,
+            "label": PROFILE_LABELS.get(k, k),
+            "value": profile.get(k, PROFILE_DEFAULTS.get(k, "")),
+        }
+        for k in PROFILE_FIELDS
+    ]
+    return {"profile": profile, "fields": fields, "configured": any(v.strip() for v in profile.values())}
+
+
+@app.put("/profile")
+def save_profile(body: UserProfileBody):
+    """Save the user profile."""
+    from agent import save_user_profile
+    save_user_profile(body.profile)
+    return {"ok": True}
+
+
 # ─── WebSocket ────────────────────────────────────────────────────────────────
 
 

--- a/platforms/web.py
+++ b/platforms/web.py
@@ -120,6 +120,25 @@ class WebAdapter(PlatformAdapter):
             )
         )
 
+        # Check if user profile is configured, request if not
+        from agent import is_profile_configured, PROFILE_FIELDS, PROFILE_LABELS, PROFILE_DEFAULTS
+        if not is_profile_configured():
+            await self._ws.send_text(
+                json.dumps(
+                    {
+                        "type": "profile_required",
+                        "fields": [
+                            {
+                                "key": k,
+                                "label": PROFILE_LABELS.get(k, k),
+                                "default": PROFILE_DEFAULTS.get(k, ""),
+                            }
+                            for k in PROFILE_FIELDS
+                        ],
+                    }
+                )
+            )
+
         task_status = task_manager.get_task_status(self._session_id)
         await self._ws.send_text(
             json.dumps(
@@ -380,6 +399,8 @@ class WebAdapter(PlatformAdapter):
             await self._handle_takeover_navigate(payload)
         elif msg_type == "user_input":
             await self._handle_user_input(payload)
+        elif msg_type == "user_profile":
+            await self._handle_user_profile(payload)
 
     async def _handle_stop_task(self) -> None:
         task_stopped = await task_manager.stop_task(self._session_id)
@@ -585,6 +606,17 @@ class WebAdapter(PlatformAdapter):
         url = payload.get("url", "")
         if url:
             await self._pm.handle_takeover_navigate(url)
+
+    async def _handle_user_profile(self, payload: dict) -> None:
+        """Save user profile data sent from the frontend dialog."""
+        from agent import save_user_profile
+        save_user_profile(payload.get("profile", {}))
+        await self._send_packet(
+            {
+                "type": "profile_saved",
+                "message": "Profile saved successfully.",
+            }
+        )
 
     async def _handle_user_input(self, payload: dict) -> None:
         user_msg: str = payload.get("message", "")


### PR DESCRIPTION
                                                                                                                                                                                                                                                                                                                                                                                                                            
 ## 概述                                                                                                                                                                                                                  
                                                                                                                                                                                                                           
  将用户档案收集从 WebSocket 弹窗流程改为侧边栏面板入口，并扩展至 11 个档案字段（新增手机号、身份证号）。档案数据持久化到 `data/user_profile.json`，自动嵌入 AI 系统提示词。                                               

  ## 变更文件

  | 文件 | 变更 |
  |------|------|
  | `agent.py` | 档案字段扩展至 11 个，新增 JSON 文件读写，`build_system_prompt()` 动态集成 |
  | `platforms/web.py` | WebSocket 新增 `profile_required` / `user_profile` / `profile_saved` 协议 |
  | `main.py` | 新增 `GET /profile` 和 `PUT /profile` REST 端点 |
  | `frontend/src/components/ProfilePanel.vue` | **新增** — 侧边栏档案面板，查看/编辑双模式 |
  | `frontend/src/components/Sidebar.vue` | 新增 User 图标入口，集成 ProfilePanel |
  | `frontend/src/App.vue` | 处理 `profile_required`/`profile_saved` 事件，默认 11 个字段 |
  | `frontend/src/locales/zh.json` | 中文翻译（手机号、身份证号） |
  | `frontend/src/locales/en.json` | 英文翻译（Phone、ID Card） |

  ## 流程

  1. 用户点击侧边栏底部 User 图标 → 打开档案面板
  2. 首次连接 WebSocket → 无档案时自动弹出面板
  3. 填写 11 个字段 → 保存 → 持久化 JSON → 嵌入 AI 提示词

  ## 档案字段

  姓名、性别、年龄、职业、所在地、兴趣爱好、语言、时区、个人简介、**手机号**、**身份证号**
